### PR TITLE
avoid locale-dependent string comparisons

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,8 +29,6 @@ import {likely} from './likely.js'
 
 const own = {}.hasOwnProperty
 
-const collator = new Intl.Collator()
-
 /**
  * @param {Schema} base
  * @param {Partial<Schema>} changes
@@ -159,7 +157,7 @@ export function bcp47Normalize(tag, options) {
   removeLikelySubtags(schema)
 
   // 5. Sort variants, and sort extensions on singleton.
-  schema.variants.sort(collator.compare)
+  schema.variants.sort()
   schema.extensions.sort(compareSingleton)
 
   // 6. Warn if fields (currently only regions) should be updated but have
@@ -323,5 +321,15 @@ function add(object, key, value) {
  * @returns {number}
  */
 function compareSingleton(left, right) {
-  return collator.compare(left.singleton, right.singleton)
+  if (left.singleton > right.singleton) {
+    return 1
+  }
+
+  if (left.singleton < right.singleton) {
+    return -1
+  }
+
+  // It is invalid to have more than one extension with the same singleton so
+  // we should never reach this code.
+  return 0
 }

--- a/test.js
+++ b/test.js
@@ -220,6 +220,7 @@ test('fixtures', function () {
     'en-us': 'en',
     'en-gb': 'en-GB',
     'en-us-x-twain': 'en-x-twain',
+    'en-a-ext1-a-ext2': 'en-a-ext1-a-ext2',
     'en-a-myext-b-another': 'en-a-myext-b-another',
     'en-bu': 'en-MM',
     en: 'en',


### PR DESCRIPTION
It doesn't seem appropriate to use locale dependent ordering to sort the variants and extensions for normalization.  The result of normalization should be consistent.

The Unicode CLDR specficiation is not specific about how these tags are sorted, it just says that they should be in "alphabetical order".  They only contain a-z (lower case) and 0-9, so for most locales alphabetical order is the same as the code point order we are now using.

This commit removes a dependency on the ECMAScript internationalization API.  This API is not available everywhere, particularly on embedded devices like TVs where storage space for internationalization data is limited.  This is important as bcp-47-normalize is now used by dash.js which in turn is used by many HbbTV applications.